### PR TITLE
Fix linter issue

### DIFF
--- a/razor/src/Payment/Method/Stripe/api/stripe-php-2.1.1/lib/ApiRequestor.php
+++ b/razor/src/Payment/Method/Stripe/api/stripe-php-2.1.1/lib/ApiRequestor.php
@@ -402,7 +402,7 @@ class ApiRequestor
 
         $url = parse_url($url);
         $port = isset($url["port"]) ? $url["port"] : 443;
-        $url = "ssl://{$url["host"]}:{$port}";
+        $url = "ssl://{$url['host']}:{$port}";
 
         $sslContext = stream_context_create(
             array('ssl' => array(


### PR DESCRIPTION
The stripe API prior to v1.1.2 had an odd statement in it that broke parsers other than Zend.
